### PR TITLE
Add a way to set renderer timeout

### DIFF
--- a/cmd/pdfgen/endpoints.go
+++ b/cmd/pdfgen/endpoints.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -54,7 +56,10 @@ func HandleProcess(ctx *fasthttp.RequestCtx) (err error) {
 	}
 
 	pdfBytes, err := runChromeDP(ctx, targetURL.String(), pdfData)
-	if err != nil {
+	if errors.Is(err, context.DeadlineExceeded) {
+		ctx.Error(err.Error(), http.StatusServiceUnavailable)
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/cmd/pdfgen/render.go
+++ b/cmd/pdfgen/render.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"time"
 
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
@@ -33,8 +34,12 @@ func runChromeDP(ctx context.Context, url string, pdfData PDFGenerationData) (bu
 		*/
 	}
 
+	// Create separate timeout context
+	timeoutCtx, tcancel := context.WithTimeout(ctx, time.Duration(rendererTimeout)*time.Millisecond)
+	defer tcancel()
+
 	// Create browser allocator
-	allocator, cancel := chromedp.NewExecAllocator(ctx, allocatorOpts...)
+	allocator, cancel := chromedp.NewExecAllocator(timeoutCtx, allocatorOpts...)
 	defer cancel()
 
 	// Create context


### PR DESCRIPTION
Under high system load, seems like Chromium gets stuck and won't pick up devtools connection.

This is a band aid for the problem, rather than a real solution.

To reproduce, start up the renderer, run `stress --cpu 16` and render a lot of documents one by one - some of them fail to render completely.